### PR TITLE
float crash issue fix

### DIFF
--- a/libs/canvas.py
+++ b/libs/canvas.py
@@ -592,11 +592,11 @@ class Canvas(QWidget):
             p.setPen(color)
             brush = QBrush(Qt.BDiagPattern)
             p.setBrush(brush)
-            p.drawRect(leftTop.x(), leftTop.y(), rectWidth, rectHeight)
+            p.drawRect(int(leftTop.x()), int(leftTop.y()), int(rectWidth), int(rectHeight))
             
             #draw dialog line of rectangle
             p.setPen(self.lineColor)
-            p.drawLine(leftTop.x(),rightBottom.y(),rightBottom.x(),leftTop.y())
+            p.drawLine(int(leftTop.x()), int(rightBottom.y()), int(rightBottom.x()), int(leftTop.y()))
 
         self.setAutoFillBackground(True)
         if self.verified:

--- a/libs/canvas.py
+++ b/libs/canvas.py
@@ -592,11 +592,11 @@ class Canvas(QWidget):
             p.setPen(color)
             brush = QBrush(Qt.BDiagPattern)
             p.setBrush(brush)
-            p.drawRect(int(leftTop.x()), int(leftTop.y()), int(rectWidth), int(rectHeight))
+            p.drawRect(QRectF(leftTop.x(), leftTop.y(), rectWidth, rectHeight))
             
             #draw dialog line of rectangle
             p.setPen(self.lineColor)
-            p.drawLine(int(leftTop.x()), int(rightBottom.y()), int(rightBottom.x()), int(leftTop.y()))
+            p.drawLine(QLineF(leftTop.x(), rightBottom.y(), rightBottom.x(), leftTop.y()))
 
         self.setAutoFillBackground(True)
         if self.verified:


### PR DESCRIPTION
When labeling some pictures , the rolabelimg reports that:
" 
roLabelImg-master\libs\canvas.py", line 599, in paintEvent
p.drawLine(leftTop.x(),rightBottom.y(),rightBottom.x(),leftTop.y())
TypeError: arguments did not match any overloaded call:
  drawLine(self, l: QLineF): argument 1 has unexpected type 'float'
  drawLine(self, line: QLine): argument 1 has unexpected type 'float'
  drawLine(self, x1: int, y1: int, x2: int, y2: int): argument 1 has unexpected type 'float'
  drawLine(self, p1: QPoint, p2: QPoint): argument 1 has unexpected type 'float'
  drawLine(self, p1: Union[QPointF, QPoint], p2: Union[QPointF, QPoint]): argument 1 has unexpected type 'float'
"
and
"
roLabelImg-master\libs\canvas.py", line 595, in paintEvent
    p.drawRect(leftTop.x(), leftTop.y(), rectWidth, rectHeight)
TypeError: arguments did not match any overloaded call:
  drawRect(self, rect: QRectF): argument 1 has unexpected type 'float'
  drawRect(self, x: int, y: int, w: int, h: int): argument 1 has unexpected type 'float'
  drawRect(self, r: QRect): argument 1 has unexpected type 'float'
"
This merge adds "int" to avoid this crash.